### PR TITLE
fix example scqt

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const double samplerate = 48000.;
 
 std::vector<double> audioInputBlock(blockSize, 0.);
 std::vector<double> audioOutputBlock(blockSize, 0.);
-std::vector<std::complex<double>> cqtDomainBuffers[octaveNumber][binsPerOctave];
+std::vector<std::complex<double>> cqtDomainBuffers[OctaveNumber][BinsPerOctave];
 
 Cqt::SlidingCqt<BinsPerOctave, OctaveNumber, Windowing> cqt;
 cqt.initFs(samplerate, blockSize);
@@ -76,13 +76,13 @@ for(unsigned i_octave = 0u; i_octave < OctaveNumber; i_octave++)
   }
 }
 
-cqt.inputBlock(audioInputBlock.data());
+cqt.inputBlock(audioInputBlock.data(), blockSize);
 for(unsigned i_octave = 0u; i_octave < OctaveNumber; i_octave++)
 {
   // All complex values for each octave and bin are stored in circular buffers and can be accessed by getting a pointer to that buffer.
   // Because the data for each octave is downsampled, the number of samples per octave and block varies.
-  const size_t nSamplesOctave = mCqt.getSamplesToProcess(i_octave);
-  CircularBuffer<std::complex<double>>* octaveCqtBuffer = mCqt.getOctaveCqtBuffer(i_octave);
+  const size_t nSamplesOctave = cqt.getSamplesToProcess(i_octave);
+  CircularBuffer<std::complex<double>>* octaveCqtBuffer = cqt.getOctaveCqtBuffer(i_octave);
   for(unsigned i_tone = 0u; i_tone < BinsPerOctave; i_tone++)
   {
     octaveCqtBuffer[i_tone].pullBlock(cqtDomainBuffers[i_octave][i_tone].data(), nSamplesOctave);

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ std::vector<double> audioOutputBlock(blockSize, 0.);
 std::vector<std::complex<double>> cqtDomainBuffers[OctaveNumber][BinsPerOctave];
 
 Cqt::SlidingCqt<BinsPerOctave, OctaveNumber, Windowing> cqt;
-cqt.initFs(samplerate, blockSize);
+cqt.init(samplerate, blockSize);
 
 for(unsigned i_octave = 0u; i_octave < OctaveNumber; i_octave++)
 {


### PR DESCRIPTION
Hello,
This is a really nice project! I've been looking into a sliding constant-Q transform implementation as a reference since I couldn't figure out some things based on the paper solely.
I had to change some variable names and arguments to make the scqt example compile on my machine.

I'm curious what bug you're encountering [here](https://github.com/jmerkt/rt-cqt/blob/1fa30bb89e4f70c9a7b904f477533f38dda95c2d/include/SlidingCqt.h#L187), do you already get good results? When I tried implementing scqt in Python I encountered problems with these periodic artifacts where it should just be a clear, straight line...
![image](https://user-images.githubusercontent.com/31353884/217804997-d3e5d2be-77f4-4afb-b22b-b6029806f965.png)

Best wishes,
Jules



